### PR TITLE
Link technology chips to official sites

### DIFF
--- a/components/technologies.html
+++ b/components/technologies.html
@@ -22,21 +22,21 @@
 				<div class="rule"></div>
 			</div>
 			<div class="chips">
-				<span class="chip chip-outline">Angular</span>
-				<span class="chip chip-outline">NGRX</span>
-				<span class="chip chip-outline">Unity</span>
-				<span class="chip chip-outline">WebGL</span>
-				<span class="chip chip-outline">React</span>
-				<span class="chip chip-outline">Next.js</span>
-				<span class="chip chip-outline">Vue.js</span>
-				<span class="chip chip-outline">Nuxt.js</span>
-				<span class="chip chip-outline">Tailwind</span>
-				<span class="chip chip-outline">Bootstrap</span>
-				<span class="chip chip-outline">Material</span>
-				<span class="chip chip-outline">TypeScript</span>
-				<span class="chip chip-outline">JavaScript</span>
-				<span class="chip chip-outline">Scss</span>
-				<span class="chip chip-outline">Css</span>
+				<a href="https://angular.dev"><span class="chip chip-outline">Angular</span></a>
+				<a href="https://ngrx.io"><span class="chip chip-outline">NGRX</span></a>
+				<a href="https://unity.com"><span class="chip chip-outline">Unity</span></a>
+				<a href="https://www.khronos.org/webgl/"><span class="chip chip-outline">WebGL</span></a>
+				<a href="https://react.dev"><span class="chip chip-outline">React</span></a>
+				<a href="https://nextjs.org"><span class="chip chip-outline">Next.js</span></a>
+				<a href="https://vuejs.org"><span class="chip chip-outline">Vue.js</span></a>
+				<a href="https://nuxt.com"><span class="chip chip-outline">Nuxt.js</span></a>
+				<a href="https://tailwindcss.com"><span class="chip chip-outline">Tailwind</span></a>
+				<a href="https://getbootstrap.com"><span class="chip chip-outline">Bootstrap</span></a>
+				<a href="https://material.io"><span class="chip chip-outline">Material</span></a>
+				<a href="https://www.typescriptlang.org"><span class="chip chip-outline">TypeScript</span></a>
+				<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript"><span class="chip chip-outline">JavaScript</span></a>
+				<a href="https://sass-lang.com"><span class="chip chip-outline">Scss</span></a>
+				<a href="https://developer.mozilla.org/en-US/docs/Web/CSS"><span class="chip chip-outline">Css</span></a>
 			</div>
 		</article>
 
@@ -50,20 +50,20 @@
 				<div class="rule"></div>
 			</div>
 			<div class="chips">
-				<span class="chip chip-outline">Node.js</span>
-				<span class="chip chip-outline">waw</span>
-				<span class="chip chip-outline">Nestjs</span>
-				<span class="chip chip-outline">Python</span>
-				<span class="chip chip-outline">Ruby on Rails</span>
-				<span class="chip chip-outline">Django</span>
-				<span class="chip chip-outline">FastAPI</span>
-				<span class="chip chip-outline">PHP/Laravel</span>
-				<span class="chip chip-outline">Java/Spring</span>
-				<span class="chip chip-outline">.NET</span>
-				<span class="chip chip-outline">Go</span>
-				<span class="chip chip-outline">Rust</span>
-				<span class="chip chip-outline">GraphQL</span>
-				<span class="chip chip-outline">Firebase</span>
+				<a href="https://nodejs.org"><span class="chip chip-outline">Node.js</span></a>
+				<a href="https://waw.js.org"><span class="chip chip-outline">waw</span></a>
+				<a href="https://nestjs.com"><span class="chip chip-outline">Nestjs</span></a>
+				<a href="https://www.python.org"><span class="chip chip-outline">Python</span></a>
+				<a href="https://rubyonrails.org"><span class="chip chip-outline">Ruby on Rails</span></a>
+				<a href="https://www.djangoproject.com"><span class="chip chip-outline">Django</span></a>
+				<a href="https://fastapi.tiangolo.com"><span class="chip chip-outline">FastAPI</span></a>
+				<a href="https://laravel.com"><span class="chip chip-outline">PHP/Laravel</span></a>
+				<a href="https://spring.io"><span class="chip chip-outline">Java/Spring</span></a>
+				<a href="https://dotnet.microsoft.com"><span class="chip chip-outline">.NET</span></a>
+				<a href="https://go.dev"><span class="chip chip-outline">Go</span></a>
+				<a href="https://www.rust-lang.org"><span class="chip chip-outline">Rust</span></a>
+				<a href="https://graphql.org"><span class="chip chip-outline">GraphQL</span></a>
+				<a href="https://firebase.google.com"><span class="chip chip-outline">Firebase</span></a>
 			</div>
 		</article>
 
@@ -77,14 +77,14 @@
 				<div class="rule"></div>
 			</div>
 			<div class="chips">
-				<span class="chip chip-outline">MongoDB</span>
-				<span class="chip chip-outline">PostgreSQL</span>
-				<span class="chip chip-outline">SQLite</span>
-				<span class="chip chip-outline">MySQL</span>
-				<span class="chip chip-outline">MariaDB</span>
-				<span class="chip chip-outline">Redis</span>
-				<span class="chip chip-outline">Elasticsearch</span>
-				<span class="chip chip-outline">CouchDB</span>
+				<a href="https://www.mongodb.com"><span class="chip chip-outline">MongoDB</span></a>
+				<a href="https://www.postgresql.org"><span class="chip chip-outline">PostgreSQL</span></a>
+				<a href="https://www.sqlite.org"><span class="chip chip-outline">SQLite</span></a>
+				<a href="https://www.mysql.com"><span class="chip chip-outline">MySQL</span></a>
+				<a href="https://mariadb.org"><span class="chip chip-outline">MariaDB</span></a>
+				<a href="https://redis.io"><span class="chip chip-outline">Redis</span></a>
+				<a href="https://www.elastic.co/elasticsearch/"><span class="chip chip-outline">Elasticsearch</span></a>
+				<a href="https://couchdb.apache.org"><span class="chip chip-outline">CouchDB</span></a>
 			</div>
 		</article>
 
@@ -98,14 +98,14 @@
 				<div class="rule"></div>
 			</div>
 			<div class="chips">
-				<span class="chip chip-outline">CI/CD Pipelines</span>
-				<span class="chip chip-outline">AWS</span>
-				<span class="chip chip-outline">Google Cloud</span>
-				<span class="chip chip-outline">Azure</span>
-				<span class="chip chip-outline">Docker</span>
-				<span class="chip chip-outline">Kubernetes</span>
-				<span class="chip chip-outline">Terraform</span>
-				<span class="chip chip-outline">Nginx</span>
+				<a href="https://en.wikipedia.org/wiki/CI/CD"><span class="chip chip-outline">CI/CD Pipelines</span></a>
+				<a href="https://aws.amazon.com"><span class="chip chip-outline">AWS</span></a>
+				<a href="https://cloud.google.com"><span class="chip chip-outline">Google Cloud</span></a>
+				<a href="https://azure.microsoft.com"><span class="chip chip-outline">Azure</span></a>
+				<a href="https://www.docker.com"><span class="chip chip-outline">Docker</span></a>
+				<a href="https://kubernetes.io"><span class="chip chip-outline">Kubernetes</span></a>
+				<a href="https://www.terraform.io"><span class="chip chip-outline">Terraform</span></a>
+				<a href="https://nginx.org"><span class="chip chip-outline">Nginx</span></a>
 			</div>
 		</article>
 
@@ -119,14 +119,14 @@
 				<div class="rule"></div>
 			</div>
 			<div class="chips">
-				<span class="chip chip-outline">Capacitor</span>
-				<span class="chip chip-outline">Cordova</span>
-				<span class="chip chip-outline">Ionic</span>
-				<span class="chip chip-outline">React Native</span>
-				<span class="chip chip-outline">Flutter</span>
-				<span class="chip chip-outline">Swift</span>
-				<span class="chip chip-outline">Kotlin</span>
-				<span class="chip chip-outline">PWA</span>
+				<a href="https://capacitorjs.com"><span class="chip chip-outline">Capacitor</span></a>
+				<a href="https://cordova.apache.org"><span class="chip chip-outline">Cordova</span></a>
+				<a href="https://ionicframework.com"><span class="chip chip-outline">Ionic</span></a>
+				<a href="https://reactnative.dev"><span class="chip chip-outline">React Native</span></a>
+				<a href="https://flutter.dev"><span class="chip chip-outline">Flutter</span></a>
+				<a href="https://www.swift.org"><span class="chip chip-outline">Swift</span></a>
+				<a href="https://kotlinlang.org"><span class="chip chip-outline">Kotlin</span></a>
+				<a href="https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps"><span class="chip chip-outline">PWA</span></a>
 			</div>
 		</article>
 
@@ -140,21 +140,21 @@
 				<div class="rule"></div>
 			</div>
 			<div class="chips">
-				<span class="chip chip-outline">Git</span>
-				<span class="chip chip-outline">GitHub</span>
-				<span class="chip chip-outline">Jira</span>
-				<span class="chip chip-outline">Trello</span>
-				<span class="chip chip-outline">Zapier</span>
-				<span class="chip chip-outline">Figma</span>
-				<span class="chip chip-outline">Canva</span>
-				<span class="chip chip-outline">Postman</span>
-				<span class="chip chip-outline">Swagger</span>
-				<span class="chip chip-outline">GraphQL</span>
-				<span class="chip chip-outline">REST APIs</span>
-				<span class="chip chip-outline">Slack</span>
-				<span class="chip chip-outline">Mattermost</span>
-				<span class="chip chip-outline">Sentry</span>
-				<span class="chip chip-outline">GPT</span>
+				<a href="https://git-scm.com"><span class="chip chip-outline">Git</span></a>
+				<a href="https://github.com"><span class="chip chip-outline">GitHub</span></a>
+				<a href="https://www.atlassian.com/software/jira"><span class="chip chip-outline">Jira</span></a>
+				<a href="https://trello.com"><span class="chip chip-outline">Trello</span></a>
+				<a href="https://zapier.com"><span class="chip chip-outline">Zapier</span></a>
+				<a href="https://www.figma.com"><span class="chip chip-outline">Figma</span></a>
+				<a href="https://www.canva.com"><span class="chip chip-outline">Canva</span></a>
+				<a href="https://www.postman.com"><span class="chip chip-outline">Postman</span></a>
+				<a href="https://swagger.io"><span class="chip chip-outline">Swagger</span></a>
+				<a href="https://graphql.org"><span class="chip chip-outline">GraphQL</span></a>
+				<a href="https://restfulapi.net"><span class="chip chip-outline">REST APIs</span></a>
+				<a href="https://slack.com"><span class="chip chip-outline">Slack</span></a>
+				<a href="https://mattermost.com"><span class="chip chip-outline">Mattermost</span></a>
+				<a href="https://sentry.io"><span class="chip chip-outline">Sentry</span></a>
+				<a href="https://openai.com/gpt"><span class="chip chip-outline">GPT</span></a>
 			</div>
 		</article>
 	</div>


### PR DESCRIPTION
## Summary
- Wrap each technology chip in `components/technologies.html` with a hyperlink to its official website.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897a6925aa88333a98e2c611cb2c72d