### PR TITLE
Add UTM source to external links

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -49,3 +49,19 @@ var y = document.getElementById("year");
 if (y) {
 	y.textContent = new Date().getFullYear();
 }
+
+// Append UTM source to external links
+document.querySelectorAll("a[href]").forEach(function (link) {
+	var url;
+	try {
+		url = new URL(link.href, window.location.href);
+	} catch (e) {
+		return;
+	}
+	if (url.hostname !== window.location.hostname) {
+		if (!url.searchParams.has("utm_source")) {
+			url.searchParams.set("utm_source", "webart.work");
+			link.href = url.toString();
+		}
+	}
+});


### PR DESCRIPTION
## Summary
- append `utm_source=webart.work` to all external links at runtime

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `node --check js/index.js`

------
https://chatgpt.com/codex/tasks/task_e_68985ab8578c8333adef9f7222e134d5